### PR TITLE
Include timestamp and uploader as part of file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # youtube-dl-subscriptions
 Downloads all new videos from your YouTube subscription feeds.
 
-I recommend to create a new folder and place the dl.py inside. You will also need a OPML file named subs.xml containing all your YouTube's subscriptions in the same folder. You can download it from https://www.youtube.com/subscription_manager?action_takeout=1 when you're logged in your YouTube account. The script will create a last.txt file inside the folder in order to remember when it was last run and not re-download the same videos again.
+I recommend to create a new folder and place the dl.py inside. You will also need a OPML file named `subscription_manager` containing all your YouTube's subscriptions in the same folder. You can download it from https://www.youtube.com/subscription_manager?action_takeout=1 when you're logged in your YouTube account. The script will create a last.txt file inside the folder in order to remember when it was last run and not re-download the same videos again.
 
 Dependencies:
 * opml


### PR DESCRIPTION
Including the timestamp and uploader (channel name) in name of the file makes it easier to find the required video easily.