### PR TITLE
Add ignore errors option for youtube-dl

### DIFF
--- a/dl.py
+++ b/dl.py
@@ -47,7 +47,7 @@ else:
     else:
         print(str(len(videos))+' new videos found')
 
-    ydl_opts = {}
+    ydl_opts = {'ignoreerrors': True}
 
     with youtube_dl.YoutubeDL(ydl_opts) as ydl:
         ydl.download(videos)


### PR DESCRIPTION
This makes sure that the script continues if youtube-dl is unable to download one of the video's